### PR TITLE
[Automated] migrate to next-gen CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/Clever/fluentd-kinesis-forwarder-monitor
+    working_directory: ~/go/src/github.com/Clever/fluentd-kinesis-forwarder-monitor
     docker:
-    - image: circleci/golang:1.16-stretch
+    - image: cimg/go:1.16
     environment:
       GOPRIVATE: github.com/Clever/*
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts


### PR DESCRIPTION
Migrate from previous-gen CircleCI Golang image to next gen one.

Previous gen images are getting deprecated, and newer ones are supposed to be faster.
